### PR TITLE
ナビゲーション表示の改善とプレースホルダ除去（#11）

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## オンライン版（公開URL）
 
-- GitHub Pages: `https://itdojp.github.io/issue-driven-work-book/`（想定）
+- GitHub Pages: `https://itdojp.github.io/issue-driven-work-book/`
 - 入口: `docs/index.md`
 
 ## 開発（ローカル）

--- a/docs/_includes/page-navigation.html
+++ b/docs/_includes/page-navigation.html
@@ -164,11 +164,6 @@ level of such grouping so only leaf items (having `path`/`url`) participate.
         <span class="label">前へ</span>
         <span class="title">{{ prev_page.title | default: prev_data.title | default: prev_data.label | default: previous_item.title | default: previous_item.name | default: "前のページ" | escape }}</span>
       </a>
-    {% else %}
-      <span class="nav-disabled nav-prev">
-        <span class="arrow" aria-hidden="true">←</span>
-        <span class="label">前へ</span>
-      </span>
     {% endif %}
 
     <a href="{{ '/' | relative_url }}" class="nav-home">
@@ -195,11 +190,6 @@ level of such grouping so only leaf items (having `path`/`url`) participate.
         <span class="title">{{ next_page.title | default: next_data.title | default: next_data.label | default: next_item.title | default: next_item.name | default: "次のページ" | escape }}</span>
         <span class="arrow" aria-hidden="true">→</span>
       </a>
-    {% else %}
-      <span class="nav-disabled nav-next">
-        <span class="label">次へ</span>
-        <span class="arrow" aria-hidden="true">→</span>
-      </span>
     {% endif %}
   </div>
 </nav>


### PR DESCRIPTION
Closes #11

- prev/next が存在しない場合、リンク無しの「← 前へ / 次へ →」を表示しないよう調整（目次へのリンクは常に表示）
- README の公開URL表記から「（想定）」等のプレースホルダを除去
