### PR TITLE
feat: add a reader-facing glossary

### DIFF
--- a/book-config.json
+++ b/book-config.json
@@ -68,6 +68,10 @@
       {
         "id": "references",
         "title": "参考文献"
+      },
+      {
+        "id": "glossary",
+        "title": "用語集"
       }
     ]
   },
@@ -81,7 +85,7 @@
       "conceptMap": false,
       "figureIndex": false,
       "legalNotice": true,
-      "glossary": false
+      "glossary": true
     }
   },
   "shared": {

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -29,4 +29,6 @@ appendices:
     path: "/appendices/checklists/"
   - title: "参考文献"
     path: "/appendices/references/"
+  - title: "用語集"
+    path: "/appendices/glossary/"
 

--- a/docs/appendices/glossary/index.md
+++ b/docs/appendices/glossary/index.md
@@ -1,0 +1,138 @@
+---
+title: "用語集"
+layout: book
+order: 930
+---
+
+# 用語集
+
+Issueの起票からPRの完了、ナレッジ化までに本書で使う主要用語をまとめる。定義だけで判断せず、各項目の「参照」から運用例とチェックリストを確認する。
+
+<dl class="glossary-list">
+  <div class="glossary-entry">
+    <dt id="term-issue">Issue（イシュー）</dt>
+    <dd>
+      <p class="glossary-definition">背景、目的、スコープ、受け入れ条件などを記録し、作業と合意を追跡する単位。</p>
+      <p class="glossary-reference">参照: <a href="../../chapters/chapter-02/">第2章「良い Issue テンプレ」</a></p>
+    </dd>
+  </div>
+  <div class="glossary-entry">
+    <dt id="term-pr">Pull Request（PR）</dt>
+    <dd>
+      <p class="glossary-definition">変更内容、理由、影響、テスト、ロールバックを示し、レビューと統合判断を行う単位。</p>
+      <p class="glossary-reference">参照: <a href="../../chapters/chapter-07/">第7章「PR 説明の型」</a></p>
+    </dd>
+  </div>
+  <div class="glossary-entry">
+    <dt id="term-acceptance-criteria">受け入れ条件（Acceptance Criteria）</dt>
+    <dd>
+      <p class="glossary-definition">成果物が目的を満たしたかを第三者が検証できる、観測可能な完了判定。</p>
+      <p class="glossary-reference">参照: <a href="../../chapters/chapter-02/#受け入れ条件と確認方法を対応づける">第2章「受け入れ条件と確認方法」</a></p>
+    </dd>
+  </div>
+  <div class="glossary-entry">
+    <dt id="term-given-when-then">Given-When-Then</dt>
+    <dd>
+      <p class="glossary-definition">前提条件、操作、期待結果の順に、受け入れ条件を検証可能な形で表す書式。</p>
+      <p class="glossary-reference">参照: <a href="../../chapters/chapter-02/#受け入れ条件の例given-when-then">第2章「受け入れ条件の例」</a></p>
+    </dd>
+  </div>
+  <div class="glossary-entry">
+    <dt id="term-scope">スコープ</dt>
+    <dd>
+      <p class="glossary-definition">今回のIssueやPRで変更し、確認する対象範囲。</p>
+      <p class="glossary-reference">参照: <a href="../templates/issue-task/#スコープ">Issue テンプレ「スコープ」</a></p>
+    </dd>
+  </div>
+  <div class="glossary-entry">
+    <dt id="term-non-scope">非スコープ</dt>
+    <dd>
+      <p class="glossary-definition">今回の判断や変更に含めない対象を明示し、意図しない作業拡大を防ぐ境界。</p>
+      <p class="glossary-reference">参照: <a href="../templates/issue-task/#非スコープ">Issue テンプレ「非スコープ」</a></p>
+    </dd>
+  </div>
+  <div class="glossary-entry">
+    <dt id="term-dor">Definition of Ready（DoR）</dt>
+    <dd>
+      <p class="glossary-definition">背景、目的、受け入れ条件、依存、リスクなど、着手前に揃える入口条件。</p>
+      <p class="glossary-reference">参照: <a href="../../chapters/chapter-05/#最小の-dor--dod">第5章「最小の DoR / DoD」</a></p>
+    </dd>
+  </div>
+  <div class="glossary-entry">
+    <dt id="term-dod">Definition of Done（DoD）</dt>
+    <dd>
+      <p class="glossary-definition">受け入れ条件、レビュー、CI、公開確認、必要な転記まで含めた出口条件。</p>
+      <p class="glossary-reference">参照: <a href="../../chapters/chapter-05/#pr-前後の-dod-ゲート">第5章「PR 前後の DoD ゲート」</a></p>
+    </dd>
+  </div>
+  <div class="glossary-entry">
+    <dt id="term-triage">トリアージ</dt>
+    <dd>
+      <p class="glossary-definition">影響度、緊急度、依存、対応可否を評価し、優先度と次の扱いを決める活動。</p>
+      <p class="glossary-reference">参照: <a href="../templates/triage-matrix/">トリアージ判断表</a></p>
+    </dd>
+  </div>
+  <div class="glossary-entry">
+    <dt id="term-priority">Priority（優先度）</dt>
+    <dd>
+      <p class="glossary-definition">平時タスクの実行順を表す業務上の優先度。障害影響を表すSeverityとは分けて扱う。</p>
+      <p class="glossary-reference">参照: <a href="../../chapters/chapter-04/#priority-と-severity-を混同しない">第4章「Priority と Severity」</a></p>
+    </dd>
+  </div>
+  <div class="glossary-entry">
+    <dt id="term-severity">Severity（重大度）</dt>
+    <dd>
+      <p class="glossary-definition">障害やインシデントの影響度を表す分類。平時タスクの実行順とは目的が異なる。</p>
+      <p class="glossary-reference">参照: <a href="../../chapters/chapter-04/#priority-と-severity-を混同しない">第4章「Priority と Severity」</a></p>
+    </dd>
+  </div>
+  <div class="glossary-entry">
+    <dt id="term-blocker">ブロッカー</dt>
+    <dd>
+      <p class="glossary-definition">作業や検証の進行を止めている条件。解除条件、担当、期限とともに報告する。</p>
+      <p class="glossary-reference">参照: <a href="../../chapters/chapter-06/#ブロッカー報告の分解">第6章「ブロッカー報告の分解」</a></p>
+    </dd>
+  </div>
+  <div class="glossary-entry">
+    <dt id="term-dependency">依存関係</dt>
+    <dd>
+      <p class="glossary-definition">着手、実装、検証、完了が他のIssueや外部要因に左右される関係。</p>
+      <p class="glossary-reference">参照: <a href="../../chapters/chapter-04/#分割の観点">第4章「分割の観点」</a></p>
+    </dd>
+  </div>
+  <div class="glossary-entry">
+    <dt id="term-evidence">証跡</dt>
+    <dd>
+      <p class="glossary-definition">再現結果、ログ、テスト、CI、公開確認など、判断や完了を第三者が追跡できる記録。</p>
+      <p class="glossary-reference">参照: <a href="../../chapters/chapter-03/#最低限残すべき情報">第3章「最低限残すべき情報」</a></p>
+    </dd>
+  </div>
+  <div class="glossary-entry">
+    <dt id="term-rollback">ロールバック</dt>
+    <dd>
+      <p class="glossary-definition">変更後に問題が起きた場合、影響を抑えて既知の状態へ戻す手順と判断条件。</p>
+      <p class="glossary-reference">参照: <a href="../templates/pr/#ロールバック">PR テンプレ「ロールバック」</a></p>
+    </dd>
+  </div>
+  <div class="glossary-entry">
+    <dt id="term-review-thread">レビューthread</dt>
+    <dd>
+      <p class="glossary-definition">PR差分上の指摘と返信をひとまとまりで追跡する会話。対応または不要理由を記録して解決する。</p>
+      <p class="glossary-reference">参照: <a href="../../chapters/chapter-07/#レビューコメントへの対応方針">第7章「レビューコメントへの対応方針」</a></p>
+    </dd>
+  </div>
+  <div class="glossary-entry">
+    <dt id="term-runbook">Runbook</dt>
+    <dd>
+      <p class="glossary-definition">繰り返す運用や障害対応を、条件、手順、確認、停止・エスカレーションまで含めて再実行できる形にした文書。</p>
+      <p class="glossary-reference">参照: <a href="../../chapters/chapter-09/#転記の判断">第9章「転記の判断」</a></p>
+    </dd>
+  </div>
+  <div class="glossary-entry">
+    <dt id="term-adr">ADR（Architecture Decision Record）</dt>
+    <dd>
+      <p class="glossary-definition">背景、論点、選択肢、決定、影響を残し、重要な意思決定を後から追跡できるようにする記録。</p>
+      <p class="glossary-reference">参照: <a href="../templates/adr/">ADR テンプレ</a></p>
+    </dd>
+  </div>
+</dl>

--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -136,3 +136,39 @@
     margin-left: calc(var(--sidebar-width) * 0.9);
   }
 }
+
+/* Reader-facing glossary */
+.glossary-list {
+  display: grid;
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+.glossary-entry {
+  min-width: 0;
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.5rem;
+  background: var(--bg-secondary);
+  overflow-wrap: anywhere;
+}
+
+.glossary-entry dt {
+  margin-bottom: 0.5rem;
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+.glossary-entry dd {
+  margin: 0;
+}
+
+.glossary-entry p:last-child {
+  margin-bottom: 0;
+}
+
+@media (max-width: 640px) {
+  .glossary-entry {
+    padding: 0.75rem;
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ order: 0
 - [テンプレ集](appendices/templates/)
 - [チェックリスト集](appendices/checklists/)
 - [ケーススタディ（通し例）](appendices/case-studies/)
+- [用語集](appendices/glossary/)
 - [ライセンス](https://github.com/itdojp/issue-driven-work-book/blob/main/LICENSE.md)
 
 ## 想定読者
@@ -118,6 +119,7 @@ PR（最小例）:
 - [ケーススタディ（通し例）](appendices/case-studies/)
 - [チェックリスト集](appendices/checklists/)
 - [参考文献](appendices/references/)
+- [用語集](appendices/glossary/)
 
 ## ライセンス
 

--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
   "scripts": {
     "start": "bash scripts/jekyll.sh serve",
     "build": "bash scripts/jekyll.sh build",
-    "test": "npm run check:security && npm run check:metadata && npm run lint && npm run check-links",
+    "test": "npm run check:security && npm run check:metadata && npm run check:reader-ux && npm run check:reader-ux-regression && npm run lint && npm run check-links",
     "lint": "markdownlint -c .markdownlint.json \"docs/**/*.md\"",
     "check-links": "find docs -name '*.md' -print0 | xargs -0 -n 1 markdown-link-check -c .markdown-link-check.json",
     "deploy": "gh-pages -d _site",
     "check:metadata": "node scripts/check-metadata-consistency.js",
-    "check:security": "npm audit"
+    "check:security": "npm audit",
+    "check:reader-ux": "node scripts/check-reader-ux.js",
+    "check:reader-ux-regression": "node scripts/check-reader-ux-regression.js"
   },
   "license": "CC-BY-NC-SA-4.0",
   "devDependencies": {

--- a/scripts/check-reader-ux-regression.js
+++ b/scripts/check-reader-ux-regression.js
@@ -55,8 +55,16 @@ for (const testCase of cases) {
       env: Object.assign({}, process.env, { READER_UX_ROOT: fixture }),
       encoding: 'utf8'
     });
-    if (result.status === 0) {
-      console.error('Negative regression failed to reject: ' + name);
+    if (result.error || result.signal || result.status === null) {
+      console.error('Negative regression harness failed for ' + name + ': ' +
+        (result.error ? result.error.message : 'child terminated without an exit status'));
+      process.exitCode = 1;
+      break;
+    }
+    if (result.status !== 1) {
+      console.error(result.status === 0
+        ? 'Negative regression failed to reject: ' + name
+        : 'Negative regression returned unexpected status ' + result.status + ': ' + name);
       process.exitCode = 1;
       break;
     }

--- a/scripts/check-reader-ux-regression.js
+++ b/scripts/check-reader-ux-regression.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const childProcess = require('child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+const SCRATCH_ROOT = path.join(ROOT, '.codex-local', 'tmp');
+fs.mkdirSync(SCRATCH_ROOT, { recursive: true });
+
+const cases = [
+  ['missing module flag', 'book-config.json', function (text) { return text.replace('"glossary": true', '"glossary": false'); }],
+  ['missing route source', 'docs/appendices/glossary/index.md', function () { return null; }],
+  ['missing navigation route', 'docs/_data/navigation.yml', function (text) { return text.replace(/  - title: "用語集"\r?\n    path: "\/appendices\/glossary\/"\r?\n/, ''); }],
+  ['missing top route', 'docs/index.md', function (text) { return text.replace('- [用語集](appendices/glossary/)\n', ''); }],
+  ['missing term anchor', 'docs/appendices/glossary/index.md', function (text) { return text.replace('id="term-issue"', 'id="issue"'); }],
+  ['missing definition', 'docs/appendices/glossary/index.md', function (text) { return text.replace('class="glossary-definition"', 'class="definition"'); }],
+  ['missing canonical reference', 'docs/appendices/glossary/index.md', function (text) { return text.replace('href="../../chapters/chapter-02/"', 'href="../../chapters/chapter-01/"'); }],
+  ['duplicate term anchor', 'docs/appendices/glossary/index.md', function (text) { return text.replace('</dl>', '  <dt id="term-issue">duplicate</dt>\n</dl>'); }],
+  ['broken target heading', 'docs/chapters/chapter-07/index.md', function (text) { return text.replace('### レビューコメントへの対応方針', '### レビュー対応'); }],
+  ['broken mobile rule', 'docs/assets/css/mobile-responsive.css', function (text) {
+    const marker = '@media (max-width: 640px)';
+    const start = text.indexOf(marker);
+    if (start < 0) return text;
+    return text.slice(0, start) + text.slice(start).replace('.glossary-entry {', '.broken-mobile-selector {');
+  }],
+  ['broken sidebar renderer', 'docs/_includes/sidebar-nav.html', function (text) { return text.replaceAll('navigation.appendices', 'navigation.resources_only'); }],
+  ['broken prev-next renderer', 'docs/_includes/page-navigation.html', function (text) { return text.replace('additional,resources,appendices,afterword', 'additional,resources,afterword'); }]
+];
+
+function createFixture() {
+  const fixture = fs.mkdtempSync(path.join(SCRATCH_ROOT, 'reader-ux-regression-'));
+  fs.copyFileSync(path.join(ROOT, 'book-config.json'), path.join(fixture, 'book-config.json'));
+  fs.copyFileSync(path.join(ROOT, 'package.json'), path.join(fixture, 'package.json'));
+  fs.cpSync(path.join(ROOT, 'docs'), path.join(fixture, 'docs'), { recursive: true });
+  return fixture;
+}
+
+let passed = 0;
+for (const testCase of cases) {
+  const name = testCase[0];
+  const relative = testCase[1];
+  const mutate = testCase[2];
+  const fixture = createFixture();
+  try {
+    const target = path.join(fixture, relative);
+    const original = fs.readFileSync(target, 'utf8');
+    const changed = mutate(original);
+    if (changed === null) fs.rmSync(target);
+    else fs.writeFileSync(target, changed);
+
+    const result = childProcess.spawnSync(process.execPath, [path.join(ROOT, 'scripts/check-reader-ux.js')], {
+      cwd: ROOT,
+      env: Object.assign({}, process.env, { READER_UX_ROOT: fixture }),
+      encoding: 'utf8'
+    });
+    if (result.status === 0) {
+      console.error('Negative regression failed to reject: ' + name);
+      process.exitCode = 1;
+      break;
+    }
+    passed += 1;
+  } finally {
+    fs.rmSync(fixture, { recursive: true, force: true });
+  }
+}
+
+if (process.exitCode) process.exit(process.exitCode);
+console.log('Reader UX negative regression passed: ' + passed + '/' + cases.length + '.');

--- a/scripts/check-reader-ux.js
+++ b/scripts/check-reader-ux.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(process.env.READER_UX_ROOT || path.join(__dirname, '..'));
+const errors = [];
+const terms = [
+  ['issue', '../../chapters/chapter-02/', 'docs/chapters/chapter-02/index.md', null],
+  ['pr', '../../chapters/chapter-07/', 'docs/chapters/chapter-07/index.md', null],
+  ['acceptance-criteria', '../../chapters/chapter-02/#受け入れ条件と確認方法を対応づける', 'docs/chapters/chapter-02/index.md', '### 受け入れ条件と確認方法を対応づける'],
+  ['given-when-then', '../../chapters/chapter-02/#受け入れ条件の例given-when-then', 'docs/chapters/chapter-02/index.md', '### 受け入れ条件の例（Given-When-Then）'],
+  ['scope', '../templates/issue-task/#スコープ', 'docs/appendices/templates/issue-task/index.md', '## スコープ'],
+  ['non-scope', '../templates/issue-task/#非スコープ', 'docs/appendices/templates/issue-task/index.md', '## 非スコープ'],
+  ['dor', '../../chapters/chapter-05/#最小の-dor--dod', 'docs/chapters/chapter-05/index.md', '### 最小の DoR / DoD'],
+  ['dod', '../../chapters/chapter-05/#pr-前後の-dod-ゲート', 'docs/chapters/chapter-05/index.md', '### PR 前後の DoD ゲート'],
+  ['triage', '../templates/triage-matrix/', 'docs/appendices/templates/triage-matrix/index.md', null],
+  ['priority', '../../chapters/chapter-04/#priority-と-severity-を混同しない', 'docs/chapters/chapter-04/index.md', '### Priority と Severity を混同しない'],
+  ['severity', '../../chapters/chapter-04/#priority-と-severity-を混同しない', 'docs/chapters/chapter-04/index.md', '### Priority と Severity を混同しない'],
+  ['blocker', '../../chapters/chapter-06/#ブロッカー報告の分解', 'docs/chapters/chapter-06/index.md', '### ブロッカー報告の分解'],
+  ['dependency', '../../chapters/chapter-04/#分割の観点', 'docs/chapters/chapter-04/index.md', '### 分割の観点'],
+  ['evidence', '../../chapters/chapter-03/#最低限残すべき情報', 'docs/chapters/chapter-03/index.md', '### 最低限残すべき情報'],
+  ['rollback', '../templates/pr/#ロールバック', 'docs/appendices/templates/pr/index.md', '## ロールバック'],
+  ['review-thread', '../../chapters/chapter-07/#レビューコメントへの対応方針', 'docs/chapters/chapter-07/index.md', '### レビューコメントへの対応方針'],
+  ['runbook', '../../chapters/chapter-09/#転記の判断', 'docs/chapters/chapter-09/index.md', '### 転記の判断'],
+  ['adr', '../templates/adr/', 'docs/appendices/templates/adr/index.md', null]
+];
+
+function read(file) {
+  try {
+    return fs.readFileSync(path.join(ROOT, file), 'utf8');
+  } catch (error) {
+    errors.push(file + ': cannot read (' + error.message + ')');
+    return '';
+  }
+}
+
+function count(text, needle) {
+  return text.split(needle).length - 1;
+}
+
+function expect(condition, message) {
+  if (!condition) errors.push(message);
+}
+
+const configText = read('book-config.json');
+let config = {};
+try {
+  config = JSON.parse(configText);
+} catch (error) {
+  errors.push('book-config.json: invalid JSON (' + error.message + ')');
+}
+const appendices = config.structure && Array.isArray(config.structure.appendices) ? config.structure.appendices : [];
+expect(config.ux && config.ux.profile === 'A', 'book-config.json: ux.profile must be A');
+expect(config.ux && config.ux.modules && config.ux.modules.glossary === true, 'book-config.json: ux.modules.glossary must be true');
+expect(appendices.filter(function (item) { return item.id === 'glossary' && item.title === '用語集'; }).length === 1,
+  'book-config.json: structure.appendices must contain one glossary entry');
+
+const glossary = read('docs/appendices/glossary/index.md');
+const nav = read('docs/_data/navigation.yml');
+const top = read('docs/index.md');
+const css = read('docs/assets/css/mobile-responsive.css');
+const layout = read('docs/_layouts/book.html');
+const sidebar = read('docs/_includes/sidebar-nav.html');
+const pageNavigation = read('docs/_includes/page-navigation.html');
+const pkgText = read('package.json');
+let pkg = {};
+try {
+  pkg = JSON.parse(pkgText);
+} catch (error) {
+  errors.push('package.json: invalid JSON (' + error.message + ')');
+}
+
+expect(count(nav, 'path: "/appendices/glossary/"') === 1, 'navigation: glossary route must appear exactly once');
+expect(count(top, '](appendices/glossary/)') === 2, 'docs/index.md: glossary link must appear in quick links and appendices');
+expect(glossary.includes('title: "用語集"') && glossary.includes('order: 930'), 'glossary: expected front matter');
+expect(count(glossary, 'class="glossary-entry"') === terms.length, 'glossary: expected exactly ' + terms.length + ' entries');
+expect(count(glossary, 'class="glossary-definition"') === terms.length, 'glossary: every term needs one definition');
+expect(count(glossary, 'class="glossary-reference"') === terms.length, 'glossary: every term needs one reference');
+expect(css.includes('.glossary-list') && css.includes('.glossary-entry'), 'CSS: glossary list and entry rules are required');
+expect(/@media \(max-width: 640px\)\s*\{[\s\S]*?\.glossary-entry\s*\{[\s\S]*?padding:\s*0\.75rem;[\s\S]*?\}[\s\S]*?\}/.test(css),
+  'mobile CSS: narrow viewport must contain the glossary-entry padding rule');
+expect(layout.includes('{% include sidebar-nav.html %}') && layout.includes('{% include page-navigation.html %}'),
+  'book layout: sidebar and page navigation includes are required');
+expect(sidebar.includes('navigation.appendices') && sidebar.includes('item.path | relative_url'),
+  'sidebar: appendices must be rendered from navigation paths');
+expect(pageNavigation.includes('introduction,chapters,additional,resources,appendices,afterword') &&
+  pageNavigation.includes('class="nav-prev"') && pageNavigation.includes('class="nav-next"'),
+  'page navigation: appendices must participate in prev/next rendering');
+expect(pkg.scripts && pkg.scripts['check:reader-ux'] === 'node scripts/check-reader-ux.js',
+  'package.json: check:reader-ux script is missing');
+expect(pkg.scripts && pkg.scripts['check:reader-ux-regression'] === 'node scripts/check-reader-ux-regression.js',
+  'package.json: check:reader-ux-regression script is missing');
+expect(pkg.scripts && String(pkg.scripts.test || '').includes('npm run check:reader-ux') &&
+  String(pkg.scripts.test || '').includes('npm run check:reader-ux-regression'),
+  'package.json: npm test must run both reader UX checks');
+
+const ids = [];
+for (const item of terms) {
+  const id = item[0];
+  const href = item[1];
+  const targetFile = item[2];
+  const heading = item[3];
+  const marker = 'id="term-' + id + '"';
+  expect(count(glossary, marker) === 1, 'glossary: expected one stable anchor ' + marker);
+  expect(count(glossary, 'href="' + href + '"') >= 1, 'glossary: missing canonical reference for term-' + id);
+  const target = read(targetFile);
+  expect(target.length > 0, 'glossary: canonical target file is empty for term-' + id);
+  if (heading) expect(target.includes(heading), targetFile + ': canonical heading is missing for term-' + id);
+  ids.push('term-' + id);
+}
+expect(new Set(ids).size === terms.length, 'glossary: term contract contains duplicate ids');
+
+const actualAnchors = Array.from(glossary.matchAll(/<dt id="(term-[a-z0-9-]+)">/g), function (match) { return match[1]; });
+expect(actualAnchors.length === terms.length, 'glossary: unexpected or malformed term anchors');
+expect(new Set(actualAnchors).size === actualAnchors.length, 'glossary: duplicate term anchors');
+expect(!/href=""/.test(glossary), 'glossary: empty href is not allowed');
+
+if (errors.length) {
+  console.error('Reader UX check failed:');
+  for (const error of errors) console.error('- ' + error);
+  process.exit(1);
+}
+console.log('Reader UX check passed: glossary route with 18 grounded terms and canonical targets.');


### PR DESCRIPTION
## Summary

- add the dedicated /appendices/glossary/ reader route with 18 terms grounded in canonical chapters and templates
- wire the glossary into top, sidebar, prev/next navigation, source structure metadata, and Profile A module metadata
- add fail-closed reader UX checks plus 12 negative regressions for route, terms, targets, mobile CSS, sidebar, and prev/next rendering

Closes #34
Parent: itdojp/it-engineer-knowledge-architecture#250

## Verification

- npm ci
- npm audit --audit-level=moderate (0 vulnerabilities)
- npm test
- npm run build
- rendered HTML assertions: glossary route, 18 anchors, top/sidebar, references to glossary prev/next
- independent review: initial medium checker finding fixed; final medium-or-higher findings 0
- git diff --check

## Scope boundary

GitHub Actions Node.js 24 migration remains tracked separately in itdojp/it-engineer-knowledge-architecture#258.
